### PR TITLE
Fix build error on Flutter 1.26.0-12.0.pre-dev and above

### DIFF
--- a/lib/src/widget/theme.dart
+++ b/lib/src/widget/theme.dart
@@ -36,7 +36,7 @@ class _ProgressTheme extends InheritedWidget {
         this.loadingText = "请稍候";
 
   static _ProgressTheme of(BuildContext context) =>
-      context.inheritFromWidgetOfExactType(_ProgressTheme);
+      context.dependOnInheritedWidgetOfExactType<_ProgressTheme>();
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) => true;


### PR DESCRIPTION
The method `inheritFromWidgetOfExactType(T)` was deprecated after v1.12.1, and totally replaced by `dependOnInheritedWidgetOfExactType<T>()` on version `1.26.0-12.0.pre-dev`.  